### PR TITLE
InfluxReporter.report_event

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,24 @@ Resque::Failure::Multiple.classes = [InfluxReporter::Integration::Resque]
 Resque::Failure.backend = Resque::Failure::Multiple
 ```
 
+## Sending events to Influx
+
+You may want to send events instead of errors or performance traces to Influx. In this case, a method is provided:
+
+```ruby
+InfluxReporter.report_event 'event_name'
+```
+
+By default, the InfluxDB series name will be "events". You can change this with an extra parameter:
+```ruby
+InfluxReporter.report_event 'event_name', extra: { series: 'my_series' }
+```
+
+Adding tags & values is also possible:
+```ruby
+InfluxReporter.report_event 'event_name', extra: { tags: { key: 'tag' }, values: { key: 'value' } }
+```
+
 ## Manual profiling
 
 It's easy to add performance tracking wherever you want using the `InfluxReporter` module.

--- a/lib/influx_reporter.rb
+++ b/lib/influx_reporter.rb
@@ -123,6 +123,15 @@ module InfluxReporter
     client&.report_message message, opts
   end
 
+  # Send an event to InfluxReporter
+  #
+  # @param message [String]
+  # @param opts [Hash]
+  # @return [Net::HTTPResponse]
+  def self.report_event(message, opts = {})
+    client&.report_event message, opts
+  end
+
   # Captures any exceptions raised inside the block
   #
   def self.capture(&block)

--- a/lib/influx_reporter/data_builders.rb
+++ b/lib/influx_reporter/data_builders.rb
@@ -11,7 +11,7 @@ module InfluxReporter
       attr_reader :config
     end
 
-    %w[transactions error].each do |f|
+    %w[transactions error event].each do |f|
       require "influx_reporter/data_builders/#{f}"
     end
   end

--- a/lib/influx_reporter/data_builders/event.rb
+++ b/lib/influx_reporter/data_builders/event.rb
@@ -6,7 +6,7 @@ module InfluxReporter
       # @param event [InfluxReporter::Event]
       def build(event)
         {
-            series: 'events',
+            series: build_series_name(event),
             values: build_values(event),
             tags: build_tags(event),
             timestamp: event.timestamp
@@ -16,9 +16,15 @@ module InfluxReporter
       private
 
       # @param event [InfluxReporter::Event]
+      def build_series_name(event)
+        return event.extra[:series] if event.extra && event.extra[:series].is_a?(String)
+        'events'
+      end
+
+      # @param event [InfluxReporter::Event]
       def build_tags(event)
         tags = event.extra[:tags] if event.extra && event.extra[:tags].is_a?(Hash)
-        tags = event.config.tags.merge(tags)
+        tags = event.config.tags.merge(tags || {})
         tags.reject { |_, value| value.nil? || value == '' }
       end
 

--- a/lib/influx_reporter/data_builders/event.rb
+++ b/lib/influx_reporter/data_builders/event.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'influx_reporter/filter'
-
 module InfluxReporter
   module DataBuilders
     class Event < DataBuilder

--- a/lib/influx_reporter/data_builders/event.rb
+++ b/lib/influx_reporter/data_builders/event.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'influx_reporter/filter'
+
+module InfluxReporter
+  module DataBuilders
+    class Event < DataBuilder
+      # @param event [InfluxReporter::Event]
+      def build(event)
+        {
+            series: 'events',
+            values: build_values(event),
+            tags: build_tags(event),
+            timestamp: event.timestamp
+        }
+      end
+
+      private
+
+      # @param event [InfluxReporter::Event]
+      def build_tags(event)
+        tags = event.extra[:tags] if event.extra && event.extra[:tags].is_a?(Hash)
+        tags = event.config.tags.merge(tags)
+        tags.reject { |_, value| value.nil? || value == '' }
+      end
+
+      # @param event [InfluxReporter::Event]
+      def build_values(event)
+        values = {
+            message: event.message
+        }
+        values = event.extra[:values].merge(values) if event.extra && event.extra[:values].is_a?(Hash)
+
+        values.reject { |_, value| value.nil? }
+      end
+    end
+  end
+end

--- a/lib/influx_reporter/error_message.rb
+++ b/lib/influx_reporter/error_message.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/hash/deep_merge'
 require 'influx_reporter/line_cache'
 require 'influx_reporter/error_message/exception'
 require 'influx_reporter/error_message/stacktrace'
@@ -79,7 +80,7 @@ module InfluxReporter
 
     def add_extra(info)
       @extra ||= {}
-      @extra.merge! info
+      @extra.deep_merge! info
     end
   end
 end

--- a/lib/influx_reporter/event_message.rb
+++ b/lib/influx_reporter/event_message.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/hash/deep_merge'
 require 'influx_reporter/util/timestamp'
 
 module InfluxReporter
@@ -26,7 +27,7 @@ module InfluxReporter
 
     def add_extra(info)
       @extra ||= {}
-      @extra.merge! info
+      @extra.deep_merge! info
     end
   end
 end

--- a/lib/influx_reporter/event_message.rb
+++ b/lib/influx_reporter/event_message.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'influx_reporter/util/timestamp'
+
+module InfluxReporter
+  class EventMessage
+    extend Logging
+
+    def initialize(config, message, attrs = {})
+      @config = config
+
+      @message = message
+      @timestamp = Util.nanos
+
+      attrs.each do |k, v|
+        send(:"#{k}=", v)
+      end
+
+      yield self if block_given?
+    end
+
+    attr_reader :config
+    attr_accessor :message
+    attr_reader :timestamp
+    attr_accessor :extra
+
+    def add_extra(info)
+      @extra ||= {}
+      @extra.merge! info
+    end
+  end
+end

--- a/spec/influx_reporter/data_builders/event_spec.rb
+++ b/spec/influx_reporter/data_builders/event_spec.rb
@@ -27,6 +27,19 @@ module InfluxReporter
           }
           expect(subject.build(event_message)).to match(example)
         end
+
+        it 'builds an event message dict from an event with a custom series name' do
+          event_message = InfluxReporter::EventMessage.new(config, 'Event', extra: { series: 'test' })
+          example = {
+              series: 'test',
+              values: {
+                  message: 'Event'
+              },
+              tags: {},
+              timestamp: an_instance_of(Integer)
+          }
+          expect(subject.build(event_message)).to match(example)
+        end
       end
     end
   end

--- a/spec/influx_reporter/data_builders/event_spec.rb
+++ b/spec/influx_reporter/data_builders/event_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module InfluxReporter
+  module DataBuilders
+    RSpec.describe Event do
+      let(:config) { Configuration.new }
+
+      subject do
+        Event.new config
+      end
+
+      describe '#build' do
+        it 'builds an event message dict from an event' do
+          event_message = InfluxReporter::EventMessage.new(config, 'Event', extra: { tags: { key: 'tag' }, values: { key: 'value' } })
+          example = {
+              series: 'events',
+              values: {
+                  message: 'Event',
+                  key: 'value'
+              },
+              tags: {
+                  key: 'tag'
+              },
+              timestamp: an_instance_of(Integer)
+          }
+          expect(subject.build(event_message)).to match(example)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
On top of reporting errors, this allows reporting events.

This PR introduces new internal classes, that mimic the behaviour of Error, but are simpler in functionality.